### PR TITLE
Fix autoload poetry

### DIFF
--- a/poetry.el
+++ b/poetry.el
@@ -103,7 +103,7 @@
 ;; Transient interface
 ;;;;;;;;;;;;;;;;;;;;;;
 
-;;;###autoload
+;;;###autoload (autoload 'poetry "poetry" nil t)
 (define-transient-command poetry ()
   "Poetry menu."
   [:description (lambda ()


### PR DESCRIPTION
Autoload does not work. In my case, it appeared when working with doom-emacs.