### PR TITLE
Update for use with latest poetry and change tracking mode hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   # verbose only needed because of cask bug
   - cask --verbose
 install:
-  - pip install poetry
+  - pip install 'poetry==1.0.0b9'
   - pip install coveralls
 script:
   - PYTHONPATH="`pwd`" cask exec ert-runner

--- a/poetry.el
+++ b/poetry.el
@@ -509,8 +509,9 @@ It ensures that your python scripts are always executed in the right environment
   :global t
   :group 'poetry
   (if poetry-tracking-mode
-      (add-hook 'post-command-hook 'poetry-track-virtualenv)
-    (remove-hook 'post-command-hook 'poetry-track-virtualenv)
+      (add-hook 'projectile-after-switch-hook 'poetry-track-virtualenv)
+    (remove-hook 'projectile-after-switch-hook 'poetry-track-virtualenv)
+
     ;; deactivate the current poetry virtualenv
     (when (and pyvenv-virtual-env
                (member (file-name-as-directory pyvenv-virtual-env)
@@ -604,10 +605,11 @@ compilation buffer name."
     (let* ((prog (or (executable-find "poetry")
                      (poetry-error "Could not find 'poetry' executable")))
            (args (if (or (string= command "run")
+                         (string= command "config")
                          (string= command "init"))
                      (cl-concatenate 'list (list (symbol-name command))
                                      args)
-                   (cl-concatenate 'list (list "-n" "--ansi"
+                     (cl-concatenate 'list (list "-n" "--ansi"
                                                (symbol-name command))
                                    args))))
       (let ((compilation-buffer-name-function
@@ -713,8 +715,8 @@ COMPIL-BUF is the current compilation buffer."
       (let* ((json-key-type 'string)
              (data (buffer-substring-no-properties
                     (point-min) (point-max)))
-             (config (json-read-from-string (replace-regexp-in-string
-                                "'" "\"" data))))
+             (config (replace-regexp-in-string
+                                "'" "\"" data)))
         (if (string= config ":json-false")
             nil
           config)))))
@@ -811,12 +813,12 @@ If OPT is non-nil, set an optional dep."
     (setq poetry-project-venv
           (or
            ;; virtualenvs in project
-           (if (poetry-get-configuration "settings.virtualenvs.in-project")
+           (if (poetry-get-configuration "virtualenvs.in-project")
                (concat (file-name-as-directory (poetry-find-project-root))
                        ".venv")
              ;; virtualenvs elsewhere
              (car (directory-files
-                   (poetry-get-configuration "settings.virtualenvs.path")
+                   (poetry-get-configuration "virtualenvs.path")
                    t
                    (format "%s-py"
                            (poetry-get-project-name)))))


### PR DESCRIPTION
This plugin doesnt work with the newest version of poetry.

These changes fix the invocation of the `poetry config` commands.

It also changed the hook to for poetry-tracking-mode.  It now is only called after a projectile project switch as opposed to after every emacs command. This should probably be changed to work with other modes.