### PR TITLE
Fix broken config retrieval - using JSON parse when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,29 +14,32 @@ matrix:
       - sudo: required
         dist: xenial
         python: 3.7
-        env: EVM_EMACS=emacs-25.1-travis
+        env: EVM_EMACS=emacs-25.1-travis POETRY_VIRTUALENVS_IN_PROJECT=1
       - sudo: required
         dist: xenial
         python: 3.7
-        env: EVM_EMACS=emacs-25.2-travis
+        env: EVM_EMACS=emacs-25.2-travis POETRY_VIRTUALENVS_IN_PROJECT=1
       - sudo: required
         dist: xenial
         python: 3.7
-        env: EVM_EMACS=emacs-25.3-travis
+        env: EVM_EMACS=emacs-25.3-travis POETRY_VIRTUALENVS_IN_PROJECT=1
 
 env:
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.2-travis
-  - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.1-travis
-  - EVM_EMACS=emacs-26.2-travis
+  global:
+    - POETRY_VIRTUALENVS_IN_PROJECT=1
+  jobs:
+    - EVM_EMACS=emacs-25.1-travis
+    - EVM_EMACS=emacs-25.2-travis
+    - EVM_EMACS=emacs-25.3-travis
+    - EVM_EMACS=emacs-26.1-travis
+    - EVM_EMACS=emacs-26.2-travis
 before_install:
   - source ./travis-evm-cask.sh
   - evm install $EVM_EMACS --use --skip
   # verbose only needed because of cask bug
   - cask --verbose
 install:
-  - pip install 'poetry==1.0.0b9'
+  - pip install 'poetry==1.0.3'
   - pip install coveralls
 script:
   - PYTHONPATH="`pwd`" cask exec ert-runner

--- a/poetry.el
+++ b/poetry.el
@@ -710,14 +710,16 @@ COMPIL-BUF is the current compilation buffer."
               (re-search-forward "\\[ValueError\\]" nil t))
         (poetry-error "Unrecognized key configuration: %s" key))
       (goto-char (point-min))
+      ;; Parse as JSON if possible, otherwise return trimmed string
       (let* ((json-key-type 'string)
+	     (json-false nil)
              (data (buffer-substring-no-properties
                     (point-min) (point-max)))
-             (config (replace-regexp-in-string
-                                "'" "\"" data)))
-        (if (string= config ":json-false")
-            nil
-          config)))))
+             (rawconfig (replace-regexp-in-string
+                         "'" "\"" data)))
+	(condition-case nil
+	    (json-read-from-string rawconfig)
+	  (error (string-trim rawconfig)))))))
 
 (defun poetry-buffer-name (&optional suffix)
   "Return the poetry buffer name, using SUFFIX is specified."


### PR DESCRIPTION
Fix for broken `poetry-get-configuration`.  Not really sure I understood previous functionality - e.g. the comparison to :json-false despite never having been json-parsed.   This was causing, for instance, `poetry-get-virtualenv` to always return a local ('in-project') .venv directory, even when none existed, due to the virtualenvs.in-project config returning "false\n\n" which was evaluated as true.

New behavior is to try to parse as json, otherwise return the bare response after trimming whitespace.  Changes are based on responses I am seeing in the \*poetry\* buffer, e.g.

`(poetry-get-configuration "virtualenvs.in-project")`
```
false

```

`(poetry-get-configuration "virtualenvs.path")`
```
/Users/ryan/Library/Caches/pypoetry/virtualenvs

```