### PR TITLE
Fix poetry-get-virtualenv

### DIFF
--- a/poetry.el
+++ b/poetry.el
@@ -711,11 +711,11 @@ COMPIL-BUF is the current compilation buffer."
         (poetry-error "Unrecognized key configuration: %s" key))
       (goto-char (point-min))
       (let* ((json-key-type 'string)
-             (data (buffer-substring-no-properties
-                    (point-min) (point-max)))
+             (data (string-trim (buffer-substring-no-properties
+                                 (point-min) (point-max))))
              (config (replace-regexp-in-string
-                                "'" "\"" data)))
-        (if (string= config ":json-false")
+                      "'" "\"" data)))
+        (if (string= config "false")
             nil
           config)))))
 

--- a/poetry.el
+++ b/poetry.el
@@ -607,7 +607,8 @@ compilation buffer name."
                      (poetry-error "Could not find 'poetry' executable")))
            (args (if (or (string= command "run")
                          (string= command "config")
-                         (string= command "init"))
+                         (string= command "init")
+                         (string= command "env"))
                      (cl-concatenate 'list (list (symbol-name command))
                                      args)
                    (cl-concatenate 'list (list
@@ -698,6 +699,13 @@ COMPIL-BUF is the current compilation buffer."
 
 ;; Helpers
 ;;;;;;;;;;
+
+(defun poetry-get-env-info-path ()
+  (let ((bufname (poetry-call 'env '("info" "--path") nil nil t)))
+    (with-current-buffer bufname
+      (goto-char (point-min))
+      (string-trim (buffer-substring-no-properties
+                    (point-min) (point-max))))))
 
 (defun poetry-get-configuration (key)
   "Return Poetry configuration for KEY.
@@ -810,6 +818,8 @@ If OPT is non-nil, set an optional dep."
       poetry-project-venv
     (setq poetry-project-venv
           (or
+           ;; `poetry env info --path'
+           (poetry-get-env-info-path)
            ;; virtualenvs in project
            (if (poetry-get-configuration "virtualenvs.in-project")
                (concat (file-name-as-directory (poetry-find-project-root))


### PR DESCRIPTION
With Poetry version 1.0.5, this plugin was not correctly finding and activating the default virtualenv that Poetry setup for me.

I _do not_ know if this is entirely correct. Please see my commit messages. I can say that this is working _for me_. If I had to guess, I think `poetry.el` support has gotten out of sync with Poetry, as the commands I changed this to use seem like they would have been used if available, so perhaps they are new. Let me know how I can help! I am very new to the Poetry tool.