### PR TITLE
Substitute - for _ in virtualenv path

### DIFF
--- a/poetry.el
+++ b/poetry.el
@@ -899,7 +899,7 @@ If OPT is non-nil, set an optional dep."
                    (poetry-get-configuration "virtualenvs.path")
                    t
                    (format "^%s-.+-py.*$"
-                           (downcase (poetry-get-project-name))))))
+                           (downcase (replace-regexp-in-string "_" "-" (poetry-get-project-name)))))))
            nil))))
 
 (defun poetry-find-pyproject-file ()


### PR DESCRIPTION
Poetry automatically substitutes - for _ in virtualenv paths, if you have a project that has a _ in your project name, then poetry.el will fail to activate it.

```
poetry new test_environment
```
In emacs:
```
poetry-venv-workon
```