### PR TITLE
Fix a false positive when identifying poetry projects

### DIFF
--- a/poetry.el
+++ b/poetry.el
@@ -879,8 +879,13 @@ If OPT is non-nil, set an optional dep."
 (defun poetry-find-project-root ()
   "Return the poetry project root if any."
   (or poetry-project-root
-      (setq poetry-project-root
-            (locate-dominating-file default-directory "pyproject.toml"))))
+      (when-let* ((root (locate-dominating-file default-directory "pyproject.toml"))
+                  (pyproject-contents
+                   (with-temp-buffer
+                     (insert-file-contents-literally (concat (file-name-as-directory root) "pyproject.toml"))
+                     (buffer-string)))
+                  (_ (string-match "^\\[tool\\.poetry]$" pyproject-contents)))
+        (setq poetry-project-root root))))
 
 (defun poetry-get-virtualenv ()
   "Return the current poetry project virtualenv, or nil if it does not exist."


### PR DESCRIPTION
The existence of `pyproject.toml` doesn't necessarily indicate that there is a poetry project. Currently, if there is a `pyporject.toml`, then poetry.el activates. This causes errors when invoking poetry, and can even hang emacs (haven't really debugged that bit fully, but it seems like some hook keeps getting called over and over each time `poetry` fails).

This PR checks that `pyproject.toml` exists _and_ that it has a line matching exactly `[tool.poetry]`.

I know this project isn't maintained, but hopefully this patch could save others time if they run into this bug.